### PR TITLE
Fixed a warning I get with debug mode on

### DIFF
--- a/sendpress.php
+++ b/sendpress.php
@@ -1045,7 +1045,12 @@ class SendPress{
 
 	function wpdbQuery($query, $type) {
 		global $wpdb;
-		$result = $wpdb->$type( $query );
+		// eliminate warnings with debug mode
+		if($type == 'prepare'){
+			$result = $wpdb->$type( $query, array() );
+		} else {
+			$result = $wpdb->$type( $query );
+		}
 		return $result;
 	}
 


### PR DESCRIPTION
Calling $wpdb->prepare requires a second parameter which generates a warning if it is not present. This breaks the AJAX call.
