### PR TITLE
Typo breaks setting the sender

### DIFF
--- a/classes/views/class-sendpress-view-settings-account.php
+++ b/classes/views/class-sendpress-view-settings-account.php
@@ -106,7 +106,7 @@ class SendPress_View_Settings_Account extends SendPress_View_Settings {
       if ( $method == $key || strpos(strtolower($key) , $method) > 0 ) { $class = "active"; }
       echo "<div class='tab-pane $class' id='$key'>";
 ?>      
-        <p>&nbsp;<input name="sendpres-sender" type="radio"  <?php if ( $method == $key || strpos(strtolower($key) , $method) > 0 ) { ?>checked="checked"<?php } ?> id="website" value="<?php echo $key; ?>" /> Activate
+        <p>&nbsp;<input name="sendpress-sender" type="radio"  <?php if ( $method == $key || strpos(strtolower($key) , $method) > 0 ) { ?>checked="checked"<?php } ?> id="website" value="<?php echo $key; ?>" /> Activate
         <?php
         echo $sender->label();
         echo "</p><div class='well'>";


### PR DESCRIPTION
If there are more than 2 sender types, you can't change the senders.

I'd also consider removing the id="website" because it's the same ID multiple times which is invalid HTML.
