### PR TITLE
Add a filter to process HTML email

### DIFF
--- a/classes/class-sendpress-email.php
+++ b/classes/class-sendpress-email.php
@@ -194,7 +194,8 @@ class SendPress_Email {
 				$body_html = str_replace("*|EMAIL|*", $subscriber->email , $body_html );
 				$body_html = str_replace("*|ID|*", $subscriber->subscriberID , $body_html );
 			}
-				
+			
+            $body_html = apply_filters('sendpress_post_render_email', $body_html);
 			//echo  $body_html;
 
 			//print_r($email);


### PR DESCRIPTION
This is my change to allow people to process the HTML email before sending it. For example, I used this to make all links italicized and have no underline. It could be extended to do a lot with inline styles. This example was tested in gmail.

function fix_sendpress_links($html)
{
    $dom = new DomDocument();
    $dom->strictErrorChecking = false;
    @$dom->loadHtml($html);
    $aTags = $dom->getElementsByTagName('a');
    foreach ($aTags as $a) {
        $style = '';
        if ($a->hasAttribute('style')) {
            $style = $a->getAttribute('style');
        }
        $style .= ';font-style: italic; text-decoration: none';
        $a->setAttribute('style', $style);
    }
    $html = $dom->saveHtml();
    return $html;
}

add_filter('sendpress_post_render_email', 'fix_sendpress_links');
