### PR TITLE
Fix #52 WordPress 3.7 Strict Mode errors

### DIFF
--- a/classes/class-sendpress-sender.php
+++ b/classes/class-sendpress-sender.php
@@ -72,7 +72,7 @@ class SendPress_Sender {
 		return $domain;
 	}
 
-	function send_email($to, $subject, $html, $text, $istest = false ){
+	function send_email($to, $subject, $html, $text, $istest = false, $sid, $list_id, $report_id){
 		return false;
 	}
 


### PR DESCRIPTION
This is just fixing the base class to have the same signature as the derived.
Note the default "false" is now weird because parameters following that do not have defaults. There may be a better fix but this will avoid strict mode errors.
