### PR TITLE
Fix to use role index not display name

### DIFF
--- a/classes/views/class-sendpress-view-settings-access.php
+++ b/classes/views/class-sendpress-view-settings-access.php
@@ -29,7 +29,7 @@ class SendPress_View_Settings_Access extends SendPress_View_Settings {
 			if($role != 'administrator'){
 			$sp_view = false;
 
-			$role = str_replace(" ","_", strtolower( $role)  );
+			//$role = str_replace(" ","_", strtolower( $role)  );
 
 			
 			$pos = strrpos($role, "s2member");
@@ -139,7 +139,7 @@ class SendPress_View_Settings_Access extends SendPress_View_Settings {
 		{
 			if($role != 'administrator'){
 				
-			$role = str_replace(" ","_", strtolower( $role)  );
+			//$role = str_replace(" ","_", strtolower( $role)  );
 
 			
 			$pos = strrpos($role, "s2member");


### PR DESCRIPTION
We were having an issue where the role display names have been changed (from 'Contributor' to 'Supervisor'). To make SendPress still work, I changed the role checking to use the role index, not the display name. This should also prevent errors when using SendPress in a language other than English.
