### PR TITLE
Integrated the FNAME, LNAME, EMAIL, and ID template tags into the class-...

### DIFF
--- a/classes/public-views/class-sendpress-public-view-email.php
+++ b/classes/public-views/class-sendpress-public-view-email.php
@@ -23,7 +23,11 @@ class SendPress_Public_View_Email extends SendPress_Public_View{
 		if(isset($_GET['eid'])){
 			$email_id = base64_decode( $_GET['eid'] );
 		}
-		
+		// If there's a subscriber ID in the URL, we need to get the subscriber object from it to use for the str_replace below.
+		if(isset($_GET['sid'])) {
+			$subscriber_id = base64_decode( $_GET['sid'] );
+			$subscriber = SendPress_Data::get_subscriber($subscriber_id);
+		}
 		//$post = get_post($email_id);
 		$inline = false;
 		if(isset($_GET['inline']) ){
@@ -36,6 +40,16 @@ class SendPress_Public_View_Email extends SendPress_Public_View{
 	   	$message->subscriber_id( 0 );
 	   	$message->list_id( 0 );
 	   	$body = $message->html();
+		/*
+		 * If the subscriber object is set (thanks to the 'sid' above), do a str_replace to replace the FNAME, LNAME, EMAIL, and ID 
+		 * form fields with the appropriate values.
+		 */
+		if (!is_null($subscriber)) {
+			$body = str_replace("*|FNAME|*", $subscriber->firstname , $body );
+			$body = str_replace("*|LNAME|*", $subscriber->lastname , $body );
+			$body = str_replace("*|EMAIL|*", $subscriber->email , $body );
+			$body = str_replace("*|ID|*", $subscriber->subscriberID , $body );
+		}
 	   	//print_r( $body );
 	   	unset($message);
 


### PR DESCRIPTION
...sendpress-public-view-email.php file.

The tags are now replaced by the subscriber's information when the email is viewed in a browser.
