### PR TITLE
Fix warning in get_last_report() when there are no reports

### DIFF
--- a/classes/class-sendpress-data.php
+++ b/classes/class-sendpress-data.php
@@ -489,8 +489,7 @@ class SendPress_Data extends SendPress_DB_Tables {
 
     static function get_last_report(){
     	$f = get_posts(array('post_type' => 'sp_report','posts_per_page'   => 1));
-    	return $f[0];
-
+    	return isset($f[0]) ? $f[0] : '';
     }
 
 


### PR DESCRIPTION
Add isset() check
