### PR TITLE
changed from get_permalink to public_url in View button on emails table

### DIFF
--- a/classes/class-sendpress-emails-table.php
+++ b/classes/class-sendpress-emails-table.php
@@ -94,8 +94,14 @@ class SendPress_Emails_Table extends WP_List_Table {
 				 return date_i18n(get_option('date_format') , strtotime( $item->post_date ) );
 			
 			case 'actions':
+                                $open_info = array(
+                                        "id"=>$item->ID,
+                                        "view"=>"email"
+                                );
+                                $code = SendPress_Data::encrypt( $open_info );
+                                $url = SendPress_Manager::public_url($code);
 				$a = '<div class="inline-buttons">';
-				$a .= '<a class="btn btn-default view-btn" title="'.  get_post_meta($item->ID, "_sendpress_subject", true) . '" href="'. get_permalink( $item->ID  ). '"><span class="glyphicon  glyphicon-eye-open"></span> '.__('View','sendpress') .'</a> ';
+				$a .= '<a class="btn btn-default view-btn" title="'.  get_post_meta($item->ID, "_sendpress_subject", true) . '" href="'.$url.'"><span class="glyphicon  glyphicon-eye-open"></span> '.__('View','sendpress') .'</a> ';
 				
 				$editwindow = 'style';
 				if(get_post_meta($item->ID  , '_sendpress_system', true) == 'new'){


### PR DESCRIPTION
Hi,

The command's encrypt and public_url  is used on SendPress_Emails_Send class and the command get_permalink() is commented, but it's used on View button on SendPress_View_Emails >> SendPress_Emails_Table. And the View button dont show the email example equal the iframe (on SendPress_Emails_Send).

