### PR TITLE
allow for doing a EXISTS or NOT EXISTS user meta query 

### DIFF
--- a/classes/views/class-sendpress-view-subscribers-listcreate.php
+++ b/classes/views/class-sendpress-view-subscribers-listcreate.php
@@ -72,7 +72,7 @@ class SendPress_View_Subscribers_Listcreate extends SendPress_View_Subscribers {
 		<input type="radio" name="sync_role" value="meta"  <?php echo $d; ?> /> <?php _e('User Meta Query - Advanced','sendpress'); ?> ( <?php _e('Use this to sync a list based on user meta data.','sendpress'); ?> )<br><br>
    		<label>Meta Key</label>
 			<input type="text" name="meta-key" value="" />
-		<?php $this->select('meta-compare', '' , array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN') ); ?>
+		<?php $this->select('meta-compare', '' , array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS') ); ?>
 
 		<label>Meta Value</label>
 			<input type="text" name="meta-value" value="" />

--- a/classes/views/class-sendpress-view-subscribers-listedit.php
+++ b/classes/views/class-sendpress-view-subscribers-listedit.php
@@ -90,7 +90,7 @@ class SendPress_View_Subscribers_Listedit extends SendPress_View_Subscribers {
 		<input type="radio" name="sync_role" value="meta"  <?php echo $d; ?> /> <?php _e('User Meta Query - Advanced','sendpress'); ?> ( <?php _e('Use this to sync a list based on user meta data.','sendpress'); ?> )<br><br>
    		<label>Meta Key</label>
 			<input type="text" name="meta-key" value="<?php echo get_post_meta($listinfo->ID, 'meta-key', true); ?>" />
-		<?php $this->select('meta-compare', get_post_meta($listinfo->ID, 'meta-compare', true) , array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN') ); ?>
+		<?php $this->select('meta-compare', get_post_meta($listinfo->ID, 'meta-compare', true) , array( '=', '!=', '>', '>=', '<', '<=', 'LIKE', 'NOT LIKE', 'IN', 'NOT IN', 'EXISTS', 'NOT EXISTS') ); ?>
 
 		<label>Meta Value</label>
 		<input type="text" name="meta-value" value="<?php echo get_post_meta($listinfo->ID, 'meta-value', true); ?>" />


### PR DESCRIPTION
Added options for EXISTS and NOT EXISTS to the meta-compare dropdown for User Meta Query.

I wanted to be able to find all users who don't have a meta field set and put them into a list.