### PR TITLE
sending proper values to the filter

### DIFF
--- a/classes/class-sendpress-ajax-loader.php
+++ b/classes/class-sendpress-ajax-loader.php
@@ -317,7 +317,7 @@ class SendPress_Ajax_Loader {
 		$role   = get_post_meta( $listid, 'sync_role', true );
 		$load   = SendPress_Option::get( 'sync-per-call', 250 );
 		
-		$custom = apply_filters('spnl-role-sync-get-user-args', false , $listid , $offset_for_this_run , $number_to_sync_at_once , $role );
+		$custom = apply_filters('spnl-role-sync-get-user-args', false , $listid , $offset , $load , $role );
 		if($custom !== false){
 			$blogusers = get_users( $custom );
 		} else {


### PR DESCRIPTION
It seems to me that $offset_for_this_run and $number_to_sync_at_once are never mentioned anywhere and have no value but $offset and $load would make sense.

Hopefully this is a good fix for that.