### PR TITLE
Fix for PHP notice error on custom field required check

### DIFF
--- a/classes/sc/class-sendpress-sc-forms.php
+++ b/classes/sc/class-sendpress-sc-forms.php
@@ -491,9 +491,13 @@ class SendPress_SC_Forms extends SendPress_SC_Base {
 								$label = $value['custom_field_label'];
 								$required = false;
 
-								if(filter_var(($options['_custom_field_'.$value['id'].'_required'] === 'on'), FILTER_VALIDATE_BOOLEAN) ){ 
+								if(array_key_exists('_custom_field_'.$value['id'].'_required', $options)) {
+									if(filter_var(($options['_custom_field_'.$value['id'].'_required'] === 'on'), FILTER_VALIDATE_BOOLEAN) ){
+
 									$label = '*'.$label;
 									$required = true;
+
+									}
 								}
 
 								?>


### PR DESCRIPTION
PHP (with WordPress in development mode) shows a notice error on custom fields without a required flag:

> Notice:  Undefined index: _custom_field_1_required in […]/wordpress/wp-content/plugins/sendpress/classes/sc/class-sendpress-sc-forms.php on line 494

This fix provides a quick fix with a check, if the required flag exists in the options array.