### PR TITLE
This is not compatible with wpvip

### DIFF
--- a/sendpress.php
+++ b/sendpress.php
@@ -11,10 +11,6 @@ Text Domain: sendpress
 Domain Path: /languages/
 
 */
-if ( ! defined( 'DB_NAME' ) ) {
-	header( 'HTTP/1.0 403 Forbidden' );
-	die;
-}
 global $blog_id;
 defined( 'SENDPRESS_API_BASE' ) or define( 'SENDPRESS_API_BASE', 'http://api.sendpress.com' );
 define( 'SENDPRESS_API_VERSION', 1 );


### PR DESCRIPTION
can't activate plugin on WpVip, Automattic's own platform because of this!

Automattic's hosting WpVip GO is using advanced caching mechanisms and doesn't allow/expose the database
directly, only throught the wpsql api.

I searched through the plugin and the plugin does not need DB_NAME,
only some test-scripts:

bin-wp/install-wp-tests.sh:9: DB_NAME=$1
bin-wp/install-wp-tests.sh:96:          sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
bin-wp/install-wp-tests.sh:122: mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA


I'm not sure what the .sh are for, I can only hope they are for development purposes, because otherwise they might not work on many dockerised/contarinerised systems, etc.

Anyway, I'm pretty sure you don't need the:

-if ( ! defined( 'DB_NAME' ) ) {
-       header( 'HTTP/1.0 403 Forbidden' );
-       die;
-}


